### PR TITLE
Fixed handling of native object ids in collection

### DIFF
--- a/lib/tcoll.js
+++ b/lib/tcoll.js
@@ -422,6 +422,8 @@ tcoll.prototype._wrapTypes = function(obj) {
 
 tcoll.prototype._ensureIds = function(obj) {
 	var self = this;
+	if (_.isFunction(obj.toBSON)) obj = obj.toBSON();
+	
 	_.each(obj, function (v,k) {
 		if (k.length >0) {
 			if (k[0]=='$')
@@ -429,7 +431,7 @@ tcoll.prototype._ensureIds = function(obj) {
 			if (k.indexOf('.')!=-1)
 				throw new Error("key "+k+" must not contain '.'");
 		}
-		if (_.isObject(v)) {
+		if (_.isObject(v) && !self._tdb._gopts.nativeObjectID) {
 			if (v instanceof self._tdb.ObjectID) {
 				if (v.id<0) {
 					v._persist(++self._id)


### PR DESCRIPTION
Also fixed behavior of BSON capable objects.
This helps to use mongoose > 3 with sub schema. It serializes the object and gets rid of 'red herring' parameters in the end.